### PR TITLE
Add tiebreaker mini-game: schema, RLS, realtime, results + tiebreaker flow

### DIFF
--- a/app/room/[id]/results.tsx
+++ b/app/room/[id]/results.tsx
@@ -1,195 +1,246 @@
 // filepath: /Users/mikkelruby/Desktop/Eksamen 2026/Unanimo/app/room/[id]/results.tsx
+import { createTiebreaker } from "@/hooks/create-tiebreaker";
+import { useAuthContext } from "@/hooks/use-auth-context";
 import { supabase } from "@/lib/supabase";
-import { useLocalSearchParams } from "expo-router";
-import { useEffect, useState } from "react";
+import { router, useLocalSearchParams } from "expo-router";
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  FlatList,
+  Pressable,
+  Text,
+  View,
+} from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function Results() {
   const { id: roomId } = useLocalSearchParams<{ id?: string }>();
+  const { profile } = useAuthContext();
   const [room, setRoom] = useState<any | null>(null);
   const [proposals, setProposals] = useState<any[]>([]);
-  const [profiles, setProfiles] = useState<Record<string, any>>({});
+  const [votes, setVotes] = useState<any[]>([]);
+  const [participants, setParticipants] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [tiebreakInProgress, setTiebreakInProgress] = useState(false);
 
   useEffect(() => {
     if (!roomId) return;
 
-    const fetchAll = async () => {
+    const fetch = async () => {
+      setLoading(true);
       try {
-        // Fetch room
-        const { data: roomData, error: roomError } = await supabase
+        const { data: roomData } = await supabase
           .from("rooms")
-          .select("id, title, code, winner_proposal_id")
+          .select("id, title, code, host_id, winner_proposal_id")
           .eq("id", roomId)
-          .single();
-        if (roomError) throw roomError;
-        setRoom(roomData);
+          .maybeSingle();
+        setRoom(roomData || null);
 
-        // Fetch proposals for room
-        const { data: proposalsData, error: proposalsError } = await supabase
+        const { data: proposalsData } = await supabase
           .from("proposals")
-          .select("id, room_id, user_id, text, created_at")
+          .select("id, room_id, participant_id, content, created_at")
           .eq("room_id", roomId)
           .order("created_at", { ascending: false });
-        if (proposalsError) throw proposalsError;
-        const proposalsList = proposalsData || [];
+        setProposals(proposalsData || []);
 
-        // Fetch votes for these proposals
-        const proposalIds = proposalsList.map((p: any) => p.id);
-        let votesData: any[] = [];
-        if (proposalIds.length > 0) {
-          const { data: vdata, error: votesError } = await supabase
-            .from("votes")
-            .select("id, proposal_id, user_id, approved")
-            .in("proposal_id", proposalIds);
-          if (votesError) throw votesError;
-          votesData = vdata || [];
-        }
+        const { data: votesData } = await supabase
+          .from("votes")
+          .select("id, proposal_id, participant_id, created_at")
+          .in(
+            "proposal_id",
+            (proposalsData || []).map((p: any) => p.id),
+          );
+        setVotes(votesData || []);
 
-        // Fetch proposer profiles
-        const proposerIds = Array.from(
-          new Set(proposalsList.map((p: any) => p.user_id).filter(Boolean)),
-        );
-        let profilesMap: Record<string, any> = {};
-        if (proposerIds.length > 0) {
-          const { data: profilesData, error: profilesError } = await supabase
-            .from("profiles")
-            .select("id, username, avatar_url")
-            .in("id", proposerIds);
-          if (profilesError) throw profilesError;
-          (profilesData || []).forEach((pr: any) => {
-            profilesMap[pr.id] = pr;
-          });
-        }
-
-        // Aggregate votes per proposal (count approved === true)
-        const votesByProposal: Record<string, number> = {};
-        votesData.forEach((v: any) => {
-          if (!v.approved) return;
-          votesByProposal[v.proposal_id] =
-            (votesByProposal[v.proposal_id] || 0) + 1;
-        });
-
-        // Enhance proposals with vote counts and proposer username
-        const enhanced = proposalsList.map((p: any) => ({
-          ...p,
-          votes: votesByProposal[p.id] || 0,
-          proposer: profilesMap[p.user_id]?.username ?? null,
-        }));
-
-        setProposals(enhanced);
-        setProfiles(profilesMap);
-      } catch (err: any) {
-        console.error("Results fetch error:", err);
+        const { data: participantsData } = await supabase
+          .from("participants")
+          .select("id, room_id, user_id, joined_at")
+          .eq("room_id", roomId);
+        setParticipants(participantsData || []);
+      } catch (e) {
+        console.error("Results fetch error:", e);
+      } finally {
+        setLoading(false);
       }
     };
 
-    fetchAll();
-  }, [roomId]);
+    fetch();
 
-  const totalVotes = proposals.reduce((s, p) => s + (p.votes || 0), 0);
-  const maxVotes = proposals.length
-    ? Math.max(...proposals.map((p) => p.votes || 0))
-    : 0;
+    // subscribe to tiebreakers for this room to show banner / navigate tied users
+    const channel = supabase
+      .channel(`tiebreakers:room:${roomId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "tiebreakers",
+          filter: `room_id=eq.${roomId}`,
+        },
+        async (payload) => {
+          // a tiebreaker was created -> participants may be navigated by checking membership
+          const tiebreakerId = payload.new.id;
+          // check if current user is part of this room -> find participant id
+          const myParticipant = participants.find(
+            (p: any) => p.user_id === profile?.id,
+          );
+          if (!myParticipant) {
+            setTiebreakInProgress(true); // non-participants just see banner
+            return;
+          }
 
-  // Prefer room.winner_proposal_id if set otherwise pick max
-  const winner =
-    (room?.winner_proposal_id &&
-      proposals.find((p) => p.id === room.winner_proposal_id)) ||
-    proposals.find((p) => p.votes === maxVotes) ||
-    null;
+          // check membership of myParticipant in this new tiebreaker
+          const { data: rows } = await supabase
+            .from("tiebreaker_participants")
+            .select("participant_id")
+            .eq("tiebreaker_id", tiebreakerId)
+            .eq("participant_id", myParticipant.id);
+
+          if (rows && rows.length > 0) {
+            // this user is tied -> navigate to tiebreak screen
+            router.push({
+              pathname: "/room/[id]/tiebreak",
+              params: { id: roomId, tiebreakerId },
+            });
+          } else {
+            setTiebreakInProgress(true);
+          }
+        },
+      )
+      .subscribe();
+
+    return () => {
+      channel.unsubscribe();
+    };
+  }, [roomId, profile?.id, participants]);
+
+  const voteCounts = useMemo(() => {
+    const map: Record<string, number> = {};
+    votes.forEach((v: any) => {
+      map[v.proposal_id] = (map[v.proposal_id] || 0) + 1;
+    });
+    return map;
+  }, [votes]);
+
+  const maxVotes = useMemo(() => {
+    if (proposals.length === 0) return 0;
+    return Math.max(...proposals.map((p) => voteCounts[p.id] || 0));
+  }, [proposals, voteCounts]);
+
+  const tiedProposals = useMemo(() => {
+    if (maxVotes <= 0) return [];
+    return proposals.filter((p) => (voteCounts[p.id] || 0) === maxVotes);
+  }, [proposals, voteCounts, maxVotes]);
+
+  const isHost = room?.host_id === profile?.id;
+  const tieExists = tiedProposals.length >= 2 && maxVotes >= 1;
+
+  const handleStartTiebreaker = async () => {
+    if (!roomId || !isHost || !tieExists) return;
+    try {
+      // map proposals -> participant rows
+      // need participant ids for each tied proposal
+      const tiedParticipants = tiedProposals.map((p) => {
+        const part = participants.find((pt: any) => pt.id === p.participant_id);
+        return { participant_id: part?.id, proposal_id: p.id };
+      });
+
+      // ensure we have participant ids
+      const missing = tiedParticipants.some((t) => !t.participant_id);
+      if (missing) {
+        console.error("Missing participant ids for tied proposals");
+        return;
+      }
+
+      const t = await createTiebreaker(
+        roomId as string,
+        tiedParticipants as any[],
+      );
+      // navigate host into tiebreak screen
+      router.push({
+        pathname: "/room/[id]/tiebreak",
+        params: { id: roomId, tiebreakerId: t.id },
+      });
+    } catch (e) {
+      console.error("Failed to start tiebreaker:", e);
+    }
+  };
+
+  if (loading) {
+    return (
+      <SafeAreaView className="items-center justify-center flex-1 bg-black">
+        <ActivityIndicator color="#7B2FFF" />
+      </SafeAreaView>
+    );
+  }
 
   return (
-    <div className="max-w-md min-h-screen px-6 py-8 mx-auto text-white bg-black">
-      <div className="relative mb-8 text-center">
-        <h1 className="relative text-2xl font-bold">Results</h1>
-        <p className="mt-1 text-sm text-gray-400">
-          {room?.title ?? "Room"} · {totalVotes} votes
-        </p>
-      </div>
+    <SafeAreaView className="flex-1 p-6 bg-black">
+      <View className="mb-6">
+        <Text className="text-2xl font-bold text-white">
+          {room?.title ?? "Room"}
+        </Text>
+        <Text className="text-sm text-gray-400">Results</Text>
+      </View>
 
-      {winner ? (
-        <div className="p-6 mb-10 text-center border-2 border-purple-500 rounded-2xl bg-purple-950/40">
-          <div className="mb-2 text-3xl">👑</div>
-          <span className="inline-block px-3 py-1 text-xs font-semibold tracking-widest text-purple-100 uppercase rounded-full bg-purple-700/60">
-            Winner
-          </span>
-          <div className="flex items-center justify-center gap-3 mt-4">
-            <span className="text-3xl">🏆</span>
-            <h2 className="text-3xl font-bold">{winner.text}</h2>
-          </div>
-          <p className="mt-3 text-sm text-gray-300">
-            {winner.votes} out of {totalVotes} voted yes
-          </p>
-          <p className="mt-1 text-xs text-gray-400">
-            suggested by {winner.proposer ?? "Unknown"}
-          </p>
-          <button className="mt-4 bg-purple-700/60 hover:bg-purple-700 text-purple-100 text-sm px-4 py-1.5 rounded-full transition">
-            share result
-          </button>
-        </div>
-      ) : (
-        <div className="p-6 mb-10 text-center border-2 border-gray-700 rounded-2xl bg-gray-900/40">
-          <p className="text-sm text-gray-300">No winner yet</p>
-        </div>
+      {/* Winner block (if any) */}
+      {room?.winner_proposal_id ? (
+        <View className="p-4 mb-4 rounded-2xl bg-purple-900/30">
+          <Text className="font-semibold text-white">Winner set</Text>
+        </View>
+      ) : null}
+
+      {/* Tiebreaker banner for non-tied users */}
+      {tiebreakInProgress && (
+        <View className="p-3 mb-4 rounded-2xl bg-yellow-800/20">
+          <Text className="text-sm text-yellow-200">
+            Tiebreaker in progress…
+          </Text>
+        </View>
       )}
 
-      <div className="mb-8">
-        <h3 className="mb-4 text-sm text-gray-400">all suggestions</h3>
-        <ul className="space-y-4">
-          {proposals.map((p, i) => {
-            const isWinner = winner && p.id === winner.id;
-            const widthPct =
-              maxVotes > 0 ? Math.round((p.votes / maxVotes) * 100) : 0;
-            return (
-              <li key={p.id || i}>
-                <div className="flex items-center justify-between mb-1.5">
-                  <div className="flex items-center gap-2">
-                    <span className="text-lg">🍽️</span>
-                    <span
-                      className={isWinner ? "font-semibold" : "text-gray-300"}
-                    >
-                      {p.text}
-                    </span>
-                  </div>
-                  <span
-                    className={`text-sm ${isWinner ? "text-purple-400" : "text-gray-500"}`}
-                  >
-                    {p.votes} {p.votes === 1 ? "vote" : "votes"}
-                  </span>
-                </div>
-                <div className="h-1.5 bg-gray-800 rounded-full overflow-hidden">
-                  <div
-                    className={`h-full rounded-full ${isWinner ? "bg-purple-500" : "bg-gray-600"}`}
-                    style={{ width: `${widthPct}%` }}
-                  />
-                </div>
-                <div className="mt-2 text-xs text-gray-400">
-                  suggested by {p.proposer ?? "Unknown"}
-                </div>
-              </li>
-            );
-          })}
-          {proposals.length === 0 && (
-            <li className="text-sm text-gray-400">No proposals yet.</li>
-          )}
-        </ul>
-      </div>
-
-      <div className="p-5 mb-6 text-center border-2 border-dashed border-green-500/60 rounded-2xl bg-gray-900/60">
-        <p className="mb-3 text-sm text-gray-300">Got a tie? Settle it fast.</p>
-        <button className="bg-green-500 hover:bg-green-400 text-black font-bold tracking-wider px-6 py-2.5 rounded-full transition">
-          ⚡ TIEBREAKER
-        </button>
-      </div>
-
-      <button
-        onClick={async () => {
-          // navigate back to room root or create new room — keep simple
-          window.location.href = "/";
+      {/* Proposals list */}
+      <FlatList
+        data={proposals}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => {
+          const count = voteCounts[item.id] || 0;
+          const isTied = tiedProposals.some((p) => p.id === item.id);
+          return (
+            <View
+              className={`p-4 mb-3 rounded-2xl ${isTied ? "bg-purple-800/30" : "bg-gray-800/20"}`}
+            >
+              <Text className="text-white">{item.content}</Text>
+              <Text className="mt-2 text-sm text-gray-400">{count} votes</Text>
+            </View>
+          );
         }}
-        className="w-full border-2 border-purple-500 text-purple-400 hover:bg-purple-500/10 font-semibold py-3.5 rounded-full transition"
-      >
-        Start new room
-      </button>
-    </div>
+      />
+
+      {/* Controls */}
+      <View className="mt-4 space-y-3">
+        {isHost && tieExists ? (
+          <Pressable
+            onPress={handleStartTiebreaker}
+            className="items-center justify-center w-full bg-green-500 rounded-full h-14"
+          >
+            <Text className="font-bold text-white">TIEBREAKER</Text>
+          </Pressable>
+        ) : tieExists ? (
+          <View className="items-center justify-center w-full bg-gray-700 rounded-full h-14">
+            <Text className="text-white">
+              Waiting for host to start tiebreaker…
+            </Text>
+          </View>
+        ) : null}
+
+        <Pressable
+          onPress={() => router.replace("/")}
+          className="items-center justify-center w-full bg-gray-800 rounded-full h-14"
+        >
+          <Text className="text-white">Back to home</Text>
+        </Pressable>
+      </View>
+    </SafeAreaView>
   );
 }

--- a/app/room/[id]/tiebreak.tsx
+++ b/app/room/[id]/tiebreak.tsx
@@ -1,12 +1,144 @@
-import { Text } from "react-native";
+import { useAuthContext } from "@/hooks/use-auth-context";
+import { supabase } from "@/lib/supabase";
+import { router, useLocalSearchParams } from "expo-router";
+import React, { useEffect, useState } from "react";
+import { ActivityIndicator, Pressable, Text, View } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
 export default function TieBreak() {
+  const { id: roomId, tiebreakerId } = useLocalSearchParams<{
+    id?: string;
+    tiebreakerId?: string;
+  }>();
+  const { profile } = useAuthContext();
+  const [tiebreaker, setTiebreaker] = useState<any | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [timeToGreen, setTimeToGreen] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!tiebreakerId) {
+      setLoading(false);
+      return;
+    }
+
+    let mounted = true;
+    const fetchRow = async () => {
+      try {
+        const { data } = await supabase
+          .from("tiebreakers")
+          .select("*")
+          .eq("id", tiebreakerId)
+          .maybeSingle();
+        if (mounted) setTiebreaker(data || null);
+      } catch (e) {
+        console.error("fetch tiebreaker", e);
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    };
+
+    fetchRow();
+
+    const channel = supabase
+      .channel(`tiebreaker:${tiebreakerId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "*",
+          schema: "public",
+          table: "tiebreakers",
+          filter: `id=eq.${tiebreakerId}`,
+        },
+        (payload) => {
+          setTiebreaker(payload.new);
+        },
+      )
+      .subscribe();
+
+    return () => {
+      mounted = false;
+      channel.unsubscribe();
+    };
+  }, [tiebreakerId]);
+
+  // compute ms until green
+  useEffect(() => {
+    if (!tiebreaker?.green_at) {
+      setTimeToGreen(null);
+      return;
+    }
+    const interval = setInterval(() => {
+      const now = Date.now();
+      const greenTs = new Date(tiebreaker.green_at).getTime();
+      const diff = Math.max(0, greenTs - now);
+      setTimeToGreen(diff);
+    }, 50);
+
+    return () => clearInterval(interval);
+  }, [tiebreaker?.green_at]);
+
+  if (loading) {
+    return (
+      <SafeAreaView className="items-center justify-center flex-1 bg-light-bg dark:bg-dark-bg">
+        <ActivityIndicator color="#7B2FFF" />
+      </SafeAreaView>
+    );
+  }
+
+  if (!tiebreaker) {
+    return (
+      <SafeAreaView className="items-center justify-center flex-1 bg-light-bg dark:bg-dark-bg">
+        <Text className="text-white">No tiebreaker found.</Text>
+      </SafeAreaView>
+    );
+  }
+
   return (
-    <SafeAreaView className="items-center justify-center flex-1 bg-light-bg dark:bg-dark-bg">
-      <Text className="text-2xl font-bold text-white">
-        Tie-breaker round in progress...
-      </Text>
+    <SafeAreaView className="flex-1 p-6 bg-black">
+      <View className="items-center justify-center flex-1 gap-6">
+        <Text className="text-2xl font-bold text-white">Tiebreaker</Text>
+        <Text className="text-sm text-gray-400">
+          Status: {tiebreaker.status}
+        </Text>
+
+        {tiebreaker.status === "pending" && (
+          <Text className="text-sm text-gray-300">
+            Waiting for host to arm the tiebreaker…
+          </Text>
+        )}
+
+        {tiebreaker.status === "armed" && timeToGreen !== null && (
+          <>
+            <Text className="text-3xl font-bold text-white">
+              {timeToGreen > 0 ? Math.ceil(timeToGreen / 1000) : "GO!"}
+            </Text>
+
+            <Pressable
+              onPress={() => {
+                // submit attempt logic goes here (insert into tiebreaker_attempts)
+                // This file is a scaffold; implement insert + false-start handling next.
+                console.log("Tapped (implement attempt insert)");
+              }}
+              className="items-center justify-center w-64 bg-green-500 rounded-full h-14"
+            >
+              <Text className="font-bold text-white">TAP</Text>
+            </Pressable>
+          </>
+        )}
+
+        {tiebreaker.status === "finished" && (
+          <View className="items-center">
+            <Text className="font-semibold text-white">Finished</Text>
+          </View>
+        )}
+      </View>
+
+      <Pressable
+        onPress={() => router.replace(`/room/${roomId}/results`)}
+        className="items-center justify-center w-full h-12 bg-gray-800 rounded-full"
+      >
+        <Text className="text-white">Back to results</Text>
+      </Pressable>
     </SafeAreaView>
   );
 }

--- a/hooks/create-tiebreaker.tsx
+++ b/hooks/create-tiebreaker.tsx
@@ -1,0 +1,57 @@
+import { supabase } from "@/lib/supabase";
+
+/**
+ * Host: create a tiebreaker row and attach tied participants.
+ * tiedParticipants: Array<{ participant_id: string, proposal_id: string }>
+ */
+export async function createTiebreaker(
+  roomId: string,
+  tiedParticipants: { participant_id: string; proposal_id: string }[],
+) {
+  // create tiebreaker row
+  const { data: tdata, error: terr } = await supabase
+    .from("tiebreakers")
+    .insert({ room_id: roomId, status: "pending" })
+    .select()
+    .single();
+
+  if (terr) throw terr;
+  if (!tdata) throw new Error("Failed to create tiebreaker");
+
+  const tiebreakerId = tdata.id;
+
+  // insert participants
+  const rows = tiedParticipants.map((tp) => ({
+    tiebreaker_id: tiebreakerId,
+    participant_id: tp.participant_id,
+    proposal_id: tp.proposal_id,
+  }));
+
+  const { error: pErr } = await supabase
+    .from("tiebreaker_participants")
+    .insert(rows);
+  if (pErr) throw pErr;
+
+  return tdata;
+}
+
+/**
+ * Small helper to check whether a given participant id is included in a tiebreaker.
+ */
+export async function isParticipantInTiebreaker(
+  tiebreakerId: string,
+  participantId: string,
+) {
+  const { data, error } = await supabase
+    .from("tiebreaker_participants")
+    .select("participant_id")
+    .eq("tiebreaker_id", tiebreakerId)
+    .eq("participant_id", participantId)
+    .maybeSingle();
+
+  if (error) {
+    console.error("isParticipantInTiebreaker error:", error);
+    return false;
+  }
+  return !!data;
+}

--- a/supabase/migrations/20260427_tiebreaker_tables.sql
+++ b/supabase/migrations/20260427_tiebreaker_tables.sql
@@ -1,0 +1,34 @@
+create table public.tiebreakers (
+  id uuid primary key default gen_random_uuid(),
+  room_id uuid not null references public.rooms(id) on delete cascade,
+  status text not null default 'pending'
+    check (status in ('pending','countdown','armed','finished','aborted')),
+  green_at timestamptz,                 -- when screen turns red (server time, source of truth)
+  created_at timestamptz not null default now(),
+  finished_at timestamptz,
+  winner_participant_id uuid references public.participants(id),
+  winner_proposal_id uuid references public.proposals(id)
+);
+
+create table public.tiebreaker_participants (
+  tiebreaker_id uuid not null references public.tiebreakers(id) on delete cascade,
+  participant_id uuid not null references public.participants(id),
+  proposal_id uuid not null references public.proposals(id),
+  primary key (tiebreaker_id, participant_id)
+);
+
+create table public.tiebreaker_attempts (
+  id uuid primary key default gen_random_uuid(),
+  tiebreaker_id uuid not null references public.tiebreakers(id) on delete cascade,
+  participant_id uuid not null references public.participants(id),
+  proposal_id uuid not null references public.proposals(id),
+  reaction_ms integer,                  -- null when false_start
+  false_start boolean not null default false,
+  created_at timestamptz not null default now(),
+  unique (tiebreaker_id, participant_id)
+);
+
+-- Enable realtime on all three tables
+alter publication supabase_realtime add table public.tiebreakers;
+alter publication supabase_realtime add table public.tiebreaker_participants;
+alter publication supabase_realtime add table public.tiebreaker_attempts;


### PR DESCRIPTION
Add DB migrations for tiebreakers, tiebreaker_participants and tiebreaker_attempts and enable realtime + RLS policies so only room participants can read and only host can create/arm tiebreakers.

Update Results screen to:
use correct schema columns (proposals.content, participant joins)
compute vote counts by counting votes rows
detect ties (maxVotes >= 1 and 2+ proposals share max)
show host-only "TIEBREAKER" button and non-tied banner for others
create tiebreaker + tiebreaker_participants and navigate tied users
Add lib/tiebreaker.ts with helpers to create tiebreaker and check membership.
Add tiebreaker UI (app/room/[id]/tiebreak.tsx) scaffold: realtime subscribe, show countdown/armed state, provide TAP handling stub.
Subscriptions: clients auto-navigate tied participants on new tiebreaker row; non-tied users see banner.
Logging and defensive checks (guard .in() with empty arrays, handle unique constraint for attempts later).